### PR TITLE
Set version in package.json; run npm i to update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "abs-opds",
-  "version": "1.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abs-opds",
-      "version": "1.0.0",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.4",
-        "dotenv": "^16.5.0",
+        "dotenv": "^16.6.1",
         "fuzzy-search": "^3.2.1",
         "tsx": "^4.19.3",
         "xmlbuilder": "^15.1.1",
@@ -615,6 +615,7 @@
       "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -900,9 +901,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1873,6 +1874,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abs-opds",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "PoC for OPDS in ABS",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
Somewhat relatedly, some of the dependencies are out of date with vulnerability warnings but I didn't wanna include updating that in this PR since that'd probably warrant a 2.0.3 anway